### PR TITLE
Lift 256 character limit on alternative field.

### DIFF
--- a/grails-app/domain/grails/plugin/asyncmail/AsynchronousMailMessage.groovy
+++ b/grails-app/domain/grails/plugin/asyncmail/AsynchronousMailMessage.groovy
@@ -167,6 +167,8 @@ class AsynchronousMailMessage implements Serializable {
         )
 
         text type: 'text'
+        
+        alternative type: 'text'
 
         attachments cascade: "all-delete-orphan"
     }


### PR DESCRIPTION
Change SQL type of field AsynchronousMailMessage.alternative from VARCHAR to text to allow for email message which contain more than 256 characters.